### PR TITLE
exclude namespace management from app config

### DIFF
--- a/cluster-conf/apps/sso-dashboard/stage/ssodashboard.yaml
+++ b/cluster-conf/apps/sso-dashboard/stage/ssodashboard.yaml
@@ -1,9 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: development
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
In the past, valuable stuff outside the SSO dashboard app can be kept in the development namespace (like the SSL cert from Let's Encrypt). This prevents us from accidentally deleting the namespace and the resources contained within it. In the future, I should probably scope each app and environment to one namespace. That might be a little excessive but it doesn't hurt and it helps to segment everything.