### PR TITLE
Graylog behind Auth0 using mozilla-oidc-proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ crash.log
 # example.tfvars
 
 *.tfvars
+
+# Ignore all secrets
+*.secret.*

--- a/cluster-conf/README.md
+++ b/cluster-conf/README.md
@@ -1,1 +1,0 @@
-# eks-configuration

--- a/cluster-conf/graylog/30-oidc-proxy-config.yml
+++ b/cluster-conf/graylog/30-oidc-proxy-config.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: graylog-oidc-proxy-config
+  namespace: logging
+data:
+  backend: graylog-master.logging.svc.cluster.local:9000
+  discovery_url: https://auth.mozilla.auth0.com/.well-known/openid-configuration
+  app_name: graylog
+  aws_region: us-west-2
+

--- a/cluster-conf/graylog/30-oidc-proxy.yml
+++ b/cluster-conf/graylog/30-oidc-proxy.yml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: graylog-oidc-proxy
+  name: graylog-oidc-proxy
+  namespace: logging
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: graylog-oidc-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: graylog-oidc-proxy
+    spec:
+      containers:
+      - image:  thesmoothoperator/mozilla.oidc.accessproxy:k8s_dns_resolver
+        name: graylog-oidc-proxy
+        env:
+        - name: discovery_url
+          valueFrom:
+            configMapKeyRef:
+              name: graylog-oidc-proxy-config
+              key: discovery_url
+        - name: backend
+          valueFrom:
+            configMapKeyRef:
+              name: graylog-oidc-proxy-config
+              key:  backend
+        - name: app_name
+          valueFrom:
+            configMapKeyRef:
+              name: graylog-oidc-proxy-config
+              key: app_name
+        - name: aws_region
+          valueFrom:
+            configMapKeyRef:
+              name: graylog-oidc-proxy-config
+              key: aws_region
+        - name: client_id
+          valueFrom:
+            secretKeyRef:
+              name: graylog-oidc-proxy-secret
+              key: client_id
+        - name: client_secret
+          valueFrom:
+            secretKeyRef:
+              name: graylog-oidc-proxy-secret
+              key: client_secret
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+      securityContext:
+        runAsNonRoot: false
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: graylog-oidc-proxy
+  labels:
+    name: graylog-oidc-proxy
+    k8s-app: graylog-oidc-proxy
+  namespace: logging
+spec:
+  selector:
+    k8s-app: graylog-oidc-proxy
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+  - name: http
+    protocol: TCP
+    port: 80
+  clusterIP: None

--- a/cluster-conf/graylog/31-oidc-proxy-ingress.yml
+++ b/cluster-conf/graylog/31-oidc-proxy-ingress.yml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    certmanager.k8s.io/cluster-issuer: letsencrypt-production
+  name: graylog-oidc-proxy
+  namespace: logging
+spec:
+  tls:
+  - hosts:
+    - graylog.infra.iam.mozilla.com
+    secretName: graylog-oidc-proxy-ingress-secret
+  rules:
+  - host: graylog.infra.iam.mozilla.com
+    http:
+      paths:
+      - backend:
+          serviceName: graylog-oidc-proxy
+          servicePort: 80
+        path: /
+

--- a/infrastructure/infra-dev/prod/us-west-2/services/graylog/data.tf
+++ b/infrastructure/infra-dev/prod/us-west-2/services/graylog/data.tf
@@ -19,3 +19,12 @@ data "terraform_remote_state" "kubernetes" {
     region = "us-west-2"
   }
 }
+
+data "aws_route53_zone" "infra_iam" {
+  name = "infra.iam.mozilla.com."
+}
+
+data "aws_elb" "k8s-elb" {
+  name = "a00435690f99111e8989b0ace417809a"
+}
+

--- a/infrastructure/infra-dev/prod/us-west-2/services/graylog/domain.tf
+++ b/infrastructure/infra-dev/prod/us-west-2/services/graylog/domain.tf
@@ -1,0 +1,12 @@
+resource "aws_route53_record" "graylog" {
+  zone_id = "${data.aws_route53_zone.infra_iam.zone_id}"
+  name    = "graylog.infra.iam.mozilla.com"
+  type    = "A"
+
+  alias {
+    name                   = "dualstack.${data.aws_elb.k8s-elb.dns_name}"
+    zone_id                = "${data.aws_elb.k8s-elb.zone_id}"
+    evaluate_target_health = false
+  }
+}
+


### PR DESCRIPTION
This PR is meant to deploy all the components needed to use Auth0 with Graylog.

First, we're adding a Kubernetes Deployment which will create a pod running and [OIDC proxy](https://github.com/mozilla-iam/mozilla.oidc.accessproxy). Is using a custom image because we had to override a DNS setting in the Lua configuration. It's configured via configMap+secrets for storing client_id and secret.

After we are adding an Ingress which will expose the oidc proxy under graylog.infra.iam.mozilla.com.

And finally creating with Terraform the domain in Route53 and pointing it to the Kubernetes Ingress controller.

