### PR TITLE
Increase Prometheus retention period to 1 year

### DIFF
--- a/kubernetes/prod/us-west-2/monitoring/14-prometheus-object.yml
+++ b/kubernetes/prod/us-west-2/monitoring/14-prometheus-object.yml
@@ -74,8 +74,8 @@ spec:
         storageClassName: prometheus-storage
         resources:
           requests:
-            storage: 40Gi
-  retention: 90d
+            storage: 250Gi
+  retention: 365d
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Currently we are only keeping 90 days of data in Prometheus. I'd like to increase the retention period to 1 year in order to be able to report on these metrics, and make long term analysis.

I've resized the underlying k8s PVC to 250g and increased to retention period to 1y.