### PR TITLE
Adelbarrio/185 alert on elb

### DIFF
--- a/kubernetes/prod/us-west-2/monitoring/50-cloudwatch-exporter-configmap.yml
+++ b/kubernetes/prod/us-west-2/monitoring/50-cloudwatch-exporter-configmap.yml
@@ -11,6 +11,6 @@ data:
         aws_metric_name: SurgeQueueLength
         aws_dimensions: [LoadBalancerName]
         aws_dimension_select:
-          LoadBalancerName: [a00435690f99111e8989b0ace417809a]
+          LoadBalancerName: [a00435690f99111e8989b0ace417809a, af3ef016b807c11e9976f06f807dee91]
         aws_statistics: [Sum, Average, SampleCount, Maximum]
 

--- a/kubernetes/prod/us-west-2/monitoring/rules/elb-rules.yml
+++ b/kubernetes/prod/us-west-2/monitoring/rules/elb-rules.yml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: prometheus-general
+    role: alert-rules
+  name: elb-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: elb.rules
+    rules:
+    - alert: ELB_surge_queue_length
+      annotations:
+        message: 'ELB {{ $labels.load_balancer_name }} has a queue with more than 25 requests'
+      expr: |
+        avg(aws_elb_surge_queue_length_maximum{} offset 10m) by (load_balancer_name) > 25
+      for: 5m
+      labels:
+        severity: warning
+    - alert: ELB_surge_queue_length
+      annotations:
+        message: 'ELB {{ $labels.load_balancer_name }} has a queue with more than 250 requests'
+      expr: |
+        avg(aws_elb_surge_queue_length_maximum{} offset 10m) by (load_balancer_name) > 250
+      for: 5m
+      labels:
+        severity: critical


### PR DESCRIPTION
This PR adds rules to Alertmanager for alerting to #iam-infra-alerts when the request queue of any monitored ELB goes higher than 25 or 250 requests for warning and critical alerts respectively.
Also I created a Grafana Dashboard showing just that metric, we could add more things on it if we find useful other metrics.

I picked up those thresholds because looking at the last month, we never had a queue higher than 8 requests, and that was the peak, we normally stay in 1-2.

As you can see in the screenshot, the rules are already applied.
![rules-active](https://user-images.githubusercontent.com/9251788/58955512-822ac600-879c-11e9-826d-f4ceb0339b7f.png)

@gdestuynder @andrewkrug just adding you as a reviewers for a heads up, the code is deployed so feel free to merge it. The reason why adding these rules is described in #185 

Closes #185 