### PR TITLE
chore(k8s): Give codebuild user access to new networking API

### DIFF
--- a/kubernetes/prod/us-west-2/codebuild-rbac.yaml
+++ b/kubernetes/prod/us-west-2/codebuild-rbac.yaml
@@ -10,79 +10,9 @@ kind: ClusterRole
 metadata:
   name: codebuild-deployer
 rules:
-- apiGroups: ["","extensions","apps"]
+- apiGroups: ["","extensions","apps", "networking.k8s.io"]
   resources: ["pods","ingresses","services","namespaces","deployments","configmaps"]
   verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: mozillians-dev
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: mozillians-staging
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: mozillians-prod
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: dinopark-dev
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: dinopark-staging
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -116,49 +46,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: codebuild-deployer
-  namespace: sso-dashboard-staging
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
   namespace: sso-dashboard-prod
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: dev
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: codebuild-deployer
-subjects:
-- kind: ServiceAccount
-  name: codebuild-deployer
-  namespace: default
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: codebuild-deployer
-  namespace: dino-park
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/kubernetes/prod/us-west-2/users/dinopark-codebuild.yaml
+++ b/kubernetes/prod/us-west-2/users/dinopark-codebuild.yaml
@@ -16,6 +16,7 @@ rules:
   - ""
   - extensions
   - apps
+  - networking.k8s.io
   resources:
   - '*'
   verbs:

--- a/kubernetes/stage/us-west-2/users/dinopark-dev.yaml
+++ b/kubernetes/stage/us-west-2/users/dinopark-dev.yaml
@@ -14,6 +14,7 @@ rules:
   - watch
 - apiGroups:
   - ""
+  - networking.k8s.io
   - extensions
   - apps
   resources:


### PR DESCRIPTION
This PR failed https://github.com/mozilla-iam/dino-park-fence/commit/378d7c642edf755460b268710f000e2bc39cea0a because the user does not have access to the ingress api.

Codebuild error:
```
from server for: "STDIN": ingresses.networking.k8s.io "dino-park-nginx-ingress" is forbidden: User "dinopark-codebuild" cannot get resource "ingresses" in API group "networking.k8s.io" in the namespace "dinopark-prod"
```