### PR TITLE
sso-dashboard cloud deploy infra

### DIFF
--- a/terraform/prod/gcp-us-east1/.terraform.lock.hcl
+++ b/terraform/prod/gcp-us-east1/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "4.71.0"
+  hashes = [
+    "h1:9lCDaBOpIzKM112BUWOq5rhriRbPh7qeAaSBccGDe3s=",
+    "zh:09229ea26db8ea7a76f9dc6fd01afeb238079c2305ec9b0f44259121038f8d7d",
+    "zh:48267d46c5f0d471994c9bee2e8da48257a377afa857fdf7964faabe8313560b",
+    "zh:6db7a6c0dd2b69cba485643b7aabb8b0b4230ac36325a3a7bc1dc51b7e471a15",
+    "zh:6ff19f872fd76002b7589388dad074111e13c951674661b428a4129275312f73",
+    "zh:78fb688cea4714de48826b2e5bee1cc220b556aa6cf2fb8be9c502897c6c1d1d",
+    "zh:8794501e86249ac9c5b651417fcda5cadf88feb5f6891ad2b8d1ab9a69ea9749",
+    "zh:8d67454f019805e86717d539efb58e25d0c446a42ca1765236c8874fd9fc6935",
+    "zh:ae77bdef407cd4545cfe4b78ba4348ac5e7858cc8464c86b5cc18b5fba7b3c4c",
+    "zh:b3cd7ed642fc722398976daa63304903e8fd8a8bd6a15b6d4f434b2bb2c49cc9",
+    "zh:d2b3cd744246b42149ee2a6b509e255c10629ddfa63eeb290391016b7b56e8a0",
+    "zh:dc18f0b131e8ed78e9b0bdb55f6369e5aca246a74969d27ede6ce3188d9f9060",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/prod/gcp-us-east1/deploy.tf
+++ b/terraform/prod/gcp-us-east1/deploy.tf
@@ -1,0 +1,67 @@
+resource "google_clouddeploy_delivery_pipeline" "sso-dashboard" {
+  location = "us-east1"
+  name     = "sso-dashboard"
+  description = "Deployment pipeline for sso-dashboard"
+
+  serial_pipeline {
+    stages {
+      profiles  = ["dev"]
+      target_id = "dev"
+    }
+
+    stages {
+      profiles  = ["staging"]
+      target_id = "staging"
+    }
+
+    stages {
+      profiles  = ["prod"]
+      target_id = "prod"
+    }
+  }
+}
+
+resource "google_clouddeploy_target" "dev" {
+  location = "us-east1"
+  name     = "dev"
+  description = "Development target"
+  run {
+    location = "projects/iam-auth0/locations/us-east1"
+  }
+  execution_configs {
+    usages            = ["RENDER", "DEPLOY"]
+    execution_timeout = "3600s"
+    service_account = "sso-dashboard-prod@iam-auth0.iam.gserviceaccount.com"
+  }
+  require_approval = false
+}
+
+resource "google_clouddeploy_target" "staging" {
+  location = "us-east1"
+  name     = "staging"
+  description = "Staging target"
+  run {
+    location = "projects/iam-auth0/locations/us-east1"
+  }
+  execution_configs {
+    usages            = ["RENDER", "DEPLOY"]
+    execution_timeout = "3600s"
+    service_account = "sso-dashboard-staging@iam-auth0.iam.gserviceaccount.com"
+  }
+  require_approval = false
+}
+
+resource "google_clouddeploy_target" "prod" {
+  location = "us-east1"
+  name     = "prod"
+  description = "Production target"
+  run {
+    location = "projects/iam-auth0/locations/us-east1"
+  }
+  execution_configs {
+    usages            = ["RENDER", "DEPLOY"]
+    execution_timeout = "3600s"
+    service_account = "sso-dashboard-prod@iam-auth0.iam.gserviceaccount.com"
+  }
+  require_approval = false
+}

--- a/terraform/prod/gcp-us-east1/provider.tf
+++ b/terraform/prod/gcp-us-east1/provider.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  project     = "iam-auth0"
+  region      = "us-east1"
+}
+
+terraform {
+  backend "gcs" {
+    bucket  = "iam-auth0-terraform-state"
+    prefix  = "terraform/prod/gcp-us-east1/state"
+  }
+}


### PR DESCRIPTION
This adds already existing cloud deploy infra for deploying sso-dashboard.  Terraform remote state is stored in google cloud bucket.