### PR TITLE
Minor cleanups

### DIFF
--- a/terraform/prod/gcp-us-east1/cloudarmor.tf
+++ b/terraform/prod/gcp-us-east1/cloudarmor.tf
@@ -2,7 +2,7 @@
 #   https://github.com/mozilla-it/webservices-infra/blob/3222c6c6151ab0af2bb8607d0629e0c537d4636f/0din/tf/modules/cloudarmor/cloudarmor.tf
 
 resource "google_compute_project_cloud_armor_tier" "default" {
-  cloud_armor_tier = "CA_ENTERPRISE_PAYGO"
+  cloud_armor_tier = "CA_ENTERPRISE_ANNUAL"
 }
 
 resource "google_compute_security_policy" "default" {

--- a/terraform/prod/gcp-us-east1/dev.tf
+++ b/terraform/prod/gcp-us-east1/dev.tf
@@ -1,8 +1,3 @@
-data "google_cloud_run_v2_service" "dev" {
-  name     = "sso-dashboard-dev"
-  location = "us-east1"
-}
-
 data "google_cloud_run_v2_service" "sso_dashboard_dev" {
   name     = "sso-dashboard-dev"
   location = "us-east1"


### PR DESCRIPTION
* Turns out we're already subscribed to Cloud Armor, on the enterprise tier. So no need to specify pay as you go.
* Removing an unused `data` resource.

Jira: [IAM-1528](https://mozilla-hub.atlassian.net/browse/IAM-1528)

---

<details>
<summary>Terraform plan</summary>

```
Terraform will perform the following actions:

  # google_compute_project_cloud_armor_tier.default will be updated in-place
  ~ resource "google_compute_project_cloud_armor_tier" "default" {
      ~ cloud_armor_tier = "CA_ENTERPRISE_PAYGO" -> "CA_ENTERPRISE_ANNUAL"
        id               = "projects/iam-auth0"
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
</details>