### PR TITLE
prod Enable Cloud Armor for sso-dashboard-prod

### DIFF
--- a/terraform/prod/gcp-us-east1/prod.tf
+++ b/terraform/prod/gcp-us-east1/prod.tf
@@ -19,6 +19,7 @@ resource "google_compute_backend_service" "sso_dashboard_prod" {
   load_balancing_scheme           = "EXTERNAL_MANAGED"
   locality_lb_policy              = "ROUND_ROBIN"
   connection_draining_timeout_sec = 0
+  security_policy                 = google_compute_security_policy.default.id
   backend {
     balancing_mode  = "UTILIZATION"
     capacity_scaler = 1

--- a/terraform/prod/gcp-us-east1/prod.tf
+++ b/terraform/prod/gcp-us-east1/prod.tf
@@ -8,7 +8,7 @@ resource "google_compute_region_network_endpoint_group" "sso_dashboard_prod" {
   network_endpoint_type = "SERVERLESS"
   region                = "us-east1"
   cloud_run {
-    service = "sso-dashboard-prod"
+    service = data.google_cloud_run_v2_service.sso_dashboard_prod.name
   }
 }
 

--- a/terraform/prod/gcp-us-east1/staging.tf
+++ b/terraform/prod/gcp-us-east1/staging.tf
@@ -19,6 +19,7 @@ resource "google_compute_backend_service" "sso_dashboard_staging" {
   load_balancing_scheme           = "EXTERNAL_MANAGED"
   locality_lb_policy              = "ROUND_ROBIN"
   connection_draining_timeout_sec = 0
+  security_policy                 = google_compute_security_policy.default.id
   backend {
     balancing_mode  = "UTILIZATION"
     capacity_scaler = 1


### PR DESCRIPTION
Jira: [IAM-1528](https://mozilla-hub.atlassian.net/browse/IAM-1528)

Requires: #327 

---

<details>
<summary>Relevant Terraform plan</summary>

```
  # google_compute_backend_service.sso_dashboard_prod will be updated in-place
  ~ resource "google_compute_backend_service" "sso_dashboard_prod" {
        id                              = "projects/iam-auth0/global/backendServices/sso-dashboard-prod"
        name                            = "sso-dashboard-prod"
      + security_policy                 = "projects/iam-auth0/global/securityPolicies/default"
        # (22 unchanged attributes hidden)

        # (3 unchanged blocks hidden)
    }
```
</details>